### PR TITLE
spring-boot-rest-prometheus to 0.0.2

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -2,3 +2,6 @@ dependencies:
 - name: demo-deepu
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.12
+- name: spring-boot-rest-prometheus
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.2


### PR DESCRIPTION
Promote spring-boot-rest-prometheus to version 0.0.2